### PR TITLE
Fix polymorph

### DIFF
--- a/AIO/Combat/Mage/Arcane.cs
+++ b/AIO/Combat/Mage/Arcane.cs
@@ -3,6 +3,11 @@ using AIO.Framework;
 using AIO.Settings;
 using System.Collections.Generic;
 using static AIO.Constants;
+using System.Linq;
+using wManager.Wow.Enums;
+using wManager.Wow.Helpers;
+
+
 
 namespace AIO.Combat.Mage
 {

--- a/AIO/Combat/Mage/Arcane.cs
+++ b/AIO/Combat/Mage/Arcane.cs
@@ -12,6 +12,15 @@ namespace AIO.Combat.Mage
         protected override List<RotationStep> Rotation => new List<RotationStep> {
             new RotationStep(new RotationSpell("Shoot"), 0.9f, (s,t) => Settings.Current.UseWand && Me.ManaPercentage < Settings.Current.UseWandTresh && !RotationCombatUtil.IsAutoRepeating("Shoot"), RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Auto Attack"), 1f, (s,t) => !Me.IsCast && !RotationCombatUtil.IsAutoAttacking() && !RotationCombatUtil.IsAutoRepeating("Shoot"), RotationCombatUtil.BotTarget),
+            // Only cast Polymorph if Sheep is enabled in settings
+            new RotationStep(new RotationSpell("Polymorph"), 2.1f, (s,t) => Settings.Current.Sheep 
+            // Only cast Polymorph if more than one enemy is targeting the Mage
+            && !t.IsMyTarget && RotationFramework.Enemies.Count(o => o.IsTargetingMe) > 1 
+            // Make sure no enemies in 30 yard casting range are polymorphed right now
+            && RotationFramework.Enemies.Count(o => o.GetDistance <= 30 && o.HaveBuff("Polymorph")) < 1
+            // Only polymorph a valid target
+            && (t.IsCreatureType("Humanoid") || t.IsCreatureType("Beast") || t.IsCreatureType("Critter")),
+                RotationCombatUtil.FindEnemyTargetingMe),
             new RotationStep(new RotationSpell("Icy Veins"), 3f, (s,t) => Me.BuffStack(36032) >= 1 && t.IsBoss, RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Arcane Power"), 4f, (s,t) => Me.BuffStack(36032) >= 1 && t.IsBoss, RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Mirror Image"), 5f, (s,t) => Me.BuffStack(36032) >= 1 && t.IsBoss, RotationCombatUtil.BotTarget),

--- a/AIO/Combat/Mage/Fire.cs
+++ b/AIO/Combat/Mage/Fire.cs
@@ -14,8 +14,15 @@ namespace AIO.Combat.Mage
         protected override List<RotationStep> Rotation => new List<RotationStep> {
             new RotationStep(new RotationSpell("Shoot"), 0.9f, (s,t) => Settings.Current.UseWand && Me.ManaPercentage < Settings.Current.UseWandTresh && !RotationCombatUtil.IsAutoRepeating("Shoot"), RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Auto Attack"), 1f, (s,t) => !Me.IsCast && !RotationCombatUtil.IsAutoAttacking() && !RotationCombatUtil.IsAutoRepeating("Shoot"), RotationCombatUtil.BotTarget),
-            new RotationStep(new RotationSpell("Polymorph"),2.1f, (s,t) => Settings.Current.Sheep && !t.IsMyTarget && RotationFramework.Enemies.Count(o => o.IsTargetingMe) >1 && RotationFramework.Enemies.Count(o => o.GetDistance <= 40 && o.HaveBuff("Polymorph")) < 1 
-            && !t.IsCreatureType("Elemental") &&!t.IsCreatureType("Demon") &&!t.IsCreatureType("Undead") &&!t.IsCreatureType("Dragon"), RotationCombatUtil.FindEnemyTargetingMe),
+            // Only cast Polymorph if Sheep is enabled in settings
+            new RotationStep(new RotationSpell("Polymorph"), 2.1f, (s,t) => Settings.Current.Sheep 
+            // Only cast Polymorph if more than one enemy is targeting the Mage
+            && !t.IsMyTarget && RotationFramework.Enemies.Count(o => o.IsTargetingMe) > 1 
+            // Make sure no enemies in 30 yard casting range are polymorphed right now
+            && RotationFramework.Enemies.Count(o => o.GetDistance <= 30 && o.HaveBuff("Polymorph")) < 1
+            // Only polymorph a valid target
+            && (t.IsCreatureType("Humanoid") || t.IsCreatureType("Beast") || t.IsCreatureType("Critter")),
+                RotationCombatUtil.FindEnemyTargetingMe),
             new RotationStep(new RotationSpell("Frost Nova"), 2.2f, (s,t) => t.GetDistance <= 6 && t.HealthPercent > 30 && !Me.IsInGroup, RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Ice Block"), 3f, (s,t) => (t.HealthPercent < 15 && !t.HaveMyBuff("Ice Barrier")) || (Me.IsInGroup && Me.HealthPercent < 85), RotationCombatUtil.FindMe),
             new RotationStep(new RotationSpell("Evocation"), 3.5f, (s,t) => Me.ManaPercentage < 35, RotationCombatUtil.FindMe),

--- a/AIO/Combat/Mage/Frost.cs
+++ b/AIO/Combat/Mage/Frost.cs
@@ -16,8 +16,15 @@ namespace AIO.Combat.Mage
             new RotationStep(new RotationSpell("Shoot"), 0.9f, (s,t) => Settings.Current.UseWand && Me.ManaPercentage < Settings.Current.UseWandTresh && !RotationCombatUtil.IsAutoRepeating("Shoot"), RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Auto Attack"), 1f, (s,t) => !Me.IsCast && !RotationCombatUtil.IsAutoAttacking() && !RotationCombatUtil.IsAutoRepeating("Shoot"), RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Mana Shield"), 1.1f, (s,t) => Me.HealthPercent <= 60 && Me.ManaPercentage >= 30 && !Me.HaveBuff("Mana Shield"), RotationCombatUtil.FindMe),
-            new RotationStep(new RotationSpell("Polymorph"),2.1f, (s,t) => Settings.Current.Sheep && !t.IsMyTarget && RotationFramework.Enemies.Count(o => o.IsTargetingMe) >1 && RotationFramework.Enemies.Count(o => o.GetDistance <= 30 && o.HaveBuff("Polymorph")) < 1
-            && !t.IsCreatureType("Elemental") &&!t.IsCreatureType("Demon") &&!t.IsCreatureType("Undead") &&!t.IsCreatureType("Dragon"), RotationCombatUtil.FindEnemyTargetingMe),
+            // Only cast Polymorph if Sheep is enabled in settings
+            new RotationStep(new RotationSpell("Polymorph"), 2.1f, (s,t) => Settings.Current.Sheep 
+            // Only cast Polymorph if more than one enemy is targeting the Mage
+            && !t.IsMyTarget && RotationFramework.Enemies.Count(o => o.IsTargetingMe) > 1 
+            // Make sure no enemies in 30 yard casting range are polymorphed right now
+            && RotationFramework.Enemies.Count(o => o.GetDistance <= 30 && o.HaveBuff("Polymorph")) < 1
+            // Only polymorph a valid target
+            && (t.IsCreatureType("Humanoid") || t.IsCreatureType("Beast") || t.IsCreatureType("Critter")),
+                RotationCombatUtil.FindEnemyTargetingMe),
             new RotationStep(new RotationSpell("Frost Nova"), 2.1f, (s,t) => t.GetDistance <= 6 && t.HealthPercent > 30 && !Me.IsInGroup, RotationCombatUtil.BotTarget),
             new RotationStep(new RotationBuff("Ice Barrier"), 3f, (s,t) => t.HealthPercent < 95, RotationCombatUtil.FindMe),
             new RotationStep(new RotationSpell("Ice Block"), 4f, (s,t) => (t.HealthPercent < 15 && !t.HaveMyBuff("Ice Barrier")) || (Me.IsInGroup && Me.HealthPercent < 85), RotationCombatUtil.FindMe),

--- a/AIO/Combat/Mage/Frost.cs
+++ b/AIO/Combat/Mage/Frost.cs
@@ -25,7 +25,7 @@ namespace AIO.Combat.Mage
             // Only polymorph a valid target
             && (t.IsCreatureType("Humanoid") || t.IsCreatureType("Beast") || t.IsCreatureType("Critter")),
                 RotationCombatUtil.FindEnemyTargetingMe),
-            new RotationStep(new RotationSpell("Frost Nova"), 2.1f, (s,t) => t.GetDistance <= 6 && t.HealthPercent > 30 && !Me.IsInGroup, RotationCombatUtil.BotTarget),
+            new RotationStep(new RotationSpell("Frost Nova"), 2.2f, (s,t) => t.GetDistance <= 6 && t.HealthPercent > 30 && !Me.IsInGroup, RotationCombatUtil.BotTarget),
             new RotationStep(new RotationBuff("Ice Barrier"), 3f, (s,t) => t.HealthPercent < 95, RotationCombatUtil.FindMe),
             new RotationStep(new RotationSpell("Ice Block"), 4f, (s,t) => (t.HealthPercent < 15 && !t.HaveMyBuff("Ice Barrier")) || (Me.IsInGroup && Me.HealthPercent < 85), RotationCombatUtil.FindMe),
             new RotationStep(new RotationSpell("Cold Snap"), 5f, (s,t) => t.HealthPercent < 95 && !t.HaveMyBuff("Ice Barrier"), RotationCombatUtil.FindMe),


### PR DESCRIPTION
Updates Polymorph routine in Fire and Frost fight classes to address https://github.com/Talamin/AIO-Public/issues/1

Currently, Polymorph is cast on targets which don't match a list of invalid types. The problem is that there are also untyped enemies, such as Oozes and Mechanicals, which will cause the Mage to cast Polymorph repeatedly on invalid types.

This changes the logic to only cast Polymorph if the target is a valid type (Beast, Humanoid, Critter).

Also changes priority of Frost Nova for Frost rotation to not be the same exact priority as Polymorph (this was causing some odd behavior).