### PR TITLE
Adding Rune Tap ability to Blood Deathknights

### DIFF
--- a/AIO/Combat/DeathKnight/Blood.cs
+++ b/AIO/Combat/DeathKnight/Blood.cs
@@ -24,6 +24,7 @@ namespace AIO.Combat.DeathKnight
             // Defensive Shell on myself
             new RotationStep(new RotationSpell("Anti Magic Shell"), 3.1f, (s,t) => RotationFramework.Enemies.Count(o => o.IsCast && o.IsTargetingMe) >=1, RotationCombatUtil.FindMe),
             new RotationStep(new RotationSpell("Vampiric Blood"), 3.2f, (s,t) => Me.HealthPercent <= 30, RotationCombatUtil.FindMe),
+            new RotationStep(new RotationSpell("Rune Tap"), 3.3f, (s,t) => Me.HealthPercent <= Settings.Current.RuneTap, RotationCombatUtil.FindMe),
             // other useful  Spells
             new RotationStep(new RotationSpell("Empower Rune Weapon"), 3.5f, (s,t) => Me.RunesReadyCount() <= 2, RotationCombatUtil.FindMe),
             new RotationStep(new RotationSpell("Chains of Ice"), 3.7f, (s,t) => t.Fleeing, RotationCombatUtil.BotTarget),
@@ -40,7 +41,6 @@ namespace AIO.Combat.DeathKnight
             new RotationStep(new RotationSpell("Blood Strike"), 13f, (s,t) => RotationFramework.Enemies.Count(o => o.GetDistance <= 10) == Settings.Current.BloodStrike, RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Heart Strike"), 14f, (s,t) => RotationFramework.Enemies.Count(o => o.GetDistance <= 10) >= Settings.Current.HearthStrike, RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Blood Boil"), 15f, (s,t) => RotationFramework.Enemies.Count(o => o.GetDistance <= 10) > Settings.Current.BloodBoil, RotationCombatUtil.BotTarget),
-            new RotationStep(new RotationSpell("Rune Tap"), 15.1f, (s,t) => Me.HealthPercent < 50 && Settings.Current.RuneTap, RotationCombatUtil.FindMe),
             new RotationStep(new RotationSpell("Death Strike"), 16f, RotationCombatUtil.Always, RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Death Coil"), 17f, (s,t) => Me.RunicPower >= 40, RotationCombatUtil.BotTarget)
         };

--- a/AIO/Combat/DeathKnight/Blood.cs
+++ b/AIO/Combat/DeathKnight/Blood.cs
@@ -40,6 +40,7 @@ namespace AIO.Combat.DeathKnight
             new RotationStep(new RotationSpell("Blood Strike"), 13f, (s,t) => RotationFramework.Enemies.Count(o => o.GetDistance <= 10) == Settings.Current.BloodStrike, RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Heart Strike"), 14f, (s,t) => RotationFramework.Enemies.Count(o => o.GetDistance <= 10) >= Settings.Current.HearthStrike, RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Blood Boil"), 15f, (s,t) => RotationFramework.Enemies.Count(o => o.GetDistance <= 10) > Settings.Current.BloodBoil, RotationCombatUtil.BotTarget),
+            new RotationStep(new RotationSpell("Rune Tap"), 15.1f, (s,t) => Me.HealthPercent < 50 && Settings.Current.RuneTap, RotationCombatUtil.FindMe),
             new RotationStep(new RotationSpell("Death Strike"), 16f, RotationCombatUtil.Always, RotationCombatUtil.BotTarget),
             new RotationStep(new RotationSpell("Death Coil"), 17f, (s,t) => Me.RunicPower >= 40, RotationCombatUtil.BotTarget)
         };

--- a/AIO/Settings/DeathKnightLevelSettings.cs
+++ b/AIO/Settings/DeathKnightLevelSettings.cs
@@ -38,6 +38,13 @@ namespace AIO.Settings
         public bool DeathGrip { get; set; }
 
         [Setting]
+        [DefaultValue(true)]
+        [Category("Fight")]
+        [DisplayName("Rune tap")]
+        [Description("Use Dark Rune tap?")]
+        public bool RuneTap { get; set; }
+
+        [Setting]
         [DefaultValue(false)]
         [Category("Fight")]
         [DisplayName("Choose Presence")]
@@ -90,6 +97,7 @@ namespace AIO.Settings
             ChooseTalent = "DeathKnightBlood";
             DarkCommand = true;
             DeathGrip = true;
+            RuneTap = true;
             Presence = "BloodPresence";
             BloodStrike = 1;
             HearthStrike = 2;

--- a/AIO/Settings/DeathKnightLevelSettings.cs
+++ b/AIO/Settings/DeathKnightLevelSettings.cs
@@ -38,11 +38,12 @@ namespace AIO.Settings
         public bool DeathGrip { get; set; }
 
         [Setting]
-        [DefaultValue(true)]
+        [DefaultValue(50)]
         [Category("Fight")]
         [DisplayName("Rune tap")]
-        [Description("Use Rune tap?")]
-        public bool RuneTap { get; set; }
+        [Description("Which health % to use Rune tap?")]
+        [Percentage(true)]
+        public int RuneTap { get; set; }
 
         [Setting]
         [DefaultValue(false)]
@@ -97,7 +98,7 @@ namespace AIO.Settings
             ChooseTalent = "DeathKnightBlood";
             DarkCommand = true;
             DeathGrip = true;
-            RuneTap = true;
+            RuneTap = 50;
             Presence = "BloodPresence";
             BloodStrike = 1;
             HearthStrike = 2;

--- a/AIO/Settings/DeathKnightLevelSettings.cs
+++ b/AIO/Settings/DeathKnightLevelSettings.cs
@@ -41,7 +41,7 @@ namespace AIO.Settings
         [DefaultValue(true)]
         [Category("Fight")]
         [DisplayName("Rune tap")]
-        [Description("Use Dark Rune tap?")]
+        [Description("Use Rune tap?")]
         public bool RuneTap { get; set; }
 
         [Setting]


### PR DESCRIPTION
Please be very critical, since I'm not currently able to compile and test this.
This is coded purely on looking at the surrounding code, so it's very likely I'm missing something.

The purpose, is to add a new option for Death Knights, that enables to use of [Rune Tap](https://wotlkdb.com/?spell=48982).
It's currently enabled to true - I'm unsure if that's the best choice?

If the option is enabled, it should use Rune Tap when below 50% HP.