### PR TITLE
Update PoisonHelper.cs

### DIFF
--- a/AIO/Combat/Rogue/PoisonHelper.cs
+++ b/AIO/Combat/Rogue/PoisonHelper.cs
@@ -57,12 +57,12 @@ namespace AIO.Combat.Rogue
             return hasWeapon");
 
 
-        private static IEnumerable<uint> MP => DeadlyPoisonDictionary
+        private static IEnumerable<uint> MP => InstantPoisonDictionary
             .Where(i => i.Key <= Me.Level && ItemsManager.HasItemById(i.Value))
             .OrderByDescending(i => i.Key)
             .Select(i => i.Value);
 
-        private static IEnumerable<uint> OP => InstantPoisonDictionary
+        private static IEnumerable<uint> OP => DeadlyPoisonDictionary
             .Where(i => i.Key <= Me.Level && ItemsManager.HasItemById(i.Value))
             .OrderByDescending(i => i.Key)
             .Select(i => i.Value);


### PR DESCRIPTION
Changing Mainhand Poison to "Instant Poison" and Offhand Poison to "Deadly Poison", usually it makes sense to have a fast weapon in the offhand, as the damage isn't that big, and the quicker the offhand, the more often the Deadly Poison stacks (up to 5) are applied. Additonally a slow Mainhand gives more Damage to Sinister Strike as it is calculated based on the Mainhands Damage, one of your main attacks in the Combat Rotation.